### PR TITLE
Support multiple reflector plugin config instances

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
         working-directory: ./client-libraries/rust
 
       - name: Lint with Clippy
-        run: cargo clippy
+        run: cargo clippy --all --all-features --no-deps -- -W clippy::all -D warnings
         working-directory: ./client-libraries/rust
 
       - name: Rust unit tests

--- a/client-libraries/rust/src/ingest_client/client.rs
+++ b/client-libraries/rust/src/ingest_client/client.rs
@@ -153,7 +153,7 @@ impl IngestConnection {
                 s.write_all(&msg_len.to_be_bytes())
                     .await
                     .map_err(minicbor::encode::Error::Write)?;
-                s.write_all(&msg_buf)
+                s.write_all(msg_buf)
                     .await
                     .map_err(minicbor::encode::Error::Write)?;
             }
@@ -162,7 +162,7 @@ impl IngestConnection {
                 s.write_all(&msg_len.to_be_bytes())
                     .await
                     .map_err(minicbor::encode::Error::Write)?;
-                s.write_all(&msg_buf)
+                s.write_all(msg_buf)
                     .await
                     .map_err(minicbor::encode::Error::Write)?;
             }

--- a/client-libraries/rust/src/plugin_utils/config.rs
+++ b/client-libraries/rust/src/plugin_utils/config.rs
@@ -342,14 +342,14 @@ fn copy_relevant_plugin_section_to_top_level_metadata(
         if let Some(ingest) = &plugins.ingest {
             let plugins_ingest_member = if file_stem.looks_like_collector() {
                 ingest
-                    .collectors
-                    .get(file_stem.as_str()) // toml section: plugins.ingest.collectors.<full bin filename>
-                    .or_else(|| ingest.collectors.get(file_stem.alias())) // toml section: plugins.ingest.collectors.<stem filename>
+                    .find_collector_member_by_plugin_name(file_stem.as_str()) // toml section: plugins.ingest.collectors.<full bin filename>
+                    .or_else(|| ingest.find_collector_member_by_plugin_name(file_stem.alias()))
+            // toml section: plugins.ingest.collectors.<stem filename>
             } else if file_stem.looks_like_importer() {
                 ingest
-                    .importers
-                    .get(file_stem.as_str()) // toml section: plugins.ingest.importers.<full bin filename>
-                    .or_else(|| ingest.importers.get(file_stem.alias())) // toml section: plugins.ingest.importers.<stem filename>
+                    .find_importer_member_by_plugin_name(file_stem.as_str()) // toml section: plugins.ingest.importers.<full bin filename>
+                    .or_else(|| ingest.find_importer_member_by_plugin_name(file_stem.alias()))
+            // toml section: plugins.ingest.importers.<stem filename>
             } else {
                 None
             };
@@ -364,11 +364,12 @@ fn copy_relevant_plugin_section_to_top_level_metadata(
                 raw_toml.ingest.as_mut().unwrap().timeline_attributes =
                     pim.timeline_attributes.clone();
             }
-        } else if let Some(mutators) = plugins.mutation.as_ref().map(|m| &m.mutators) {
+        } else if let Some(mutation) = plugins.mutation.as_ref() {
             let mutations_ingest_member = if file_stem.looks_like_mutator() {
-                mutators
-                    .get(file_stem.as_str()) // toml section: plugins.mutation.mutators.<full bin filename>
-                    .or_else(|| mutators.get(file_stem.alias())) // toml section: plugins.mutation.mutators.<stem filename>
+                mutation
+                    .find_mutator_member_by_plugin_name(file_stem.as_str()) // toml section: plugins.mutation.mutators.<full bin filename>
+                    .or_else(|| mutation.find_mutator_member_by_plugin_name(file_stem.alias()))
+            // toml section: plugins.mutation.mutators.<stem filename>
             } else {
                 None
             };


### PR DESCRIPTION
* Adds new optional `plugin` field to the member config structs
* Adds lookup methods to find matching configs